### PR TITLE
Fix wrong BG-Value during backfilling from Dexcom

### DIFF
--- a/database/src/main/java/info/nightscout/androidaps/database/daos/GlucoseValueDao.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/daos/GlucoseValueDao.kt
@@ -16,7 +16,7 @@ internal interface GlucoseValueDao : TraceableDao<GlucoseValue> {
     @Query("DELETE FROM $TABLE_GLUCOSE_VALUES")
     override fun deleteAllEntries()
 
-    @Query("SELECT * FROM $TABLE_GLUCOSE_VALUES WHERE isValid = 1 AND referenceId IS NULL ORDER BY id DESC limit 1")
+    @Query("SELECT * FROM $TABLE_GLUCOSE_VALUES WHERE isValid = 1 AND referenceId IS NULL ORDER BY timestamp DESC limit 1")
     fun getLast(): Maybe<GlucoseValue>
 
     @Query("SELECT id FROM $TABLE_GLUCOSE_VALUES ORDER BY id DESC limit 1")


### PR DESCRIPTION
This change was cherry-picked from https://github.com/nightscout/AndroidAPS/commit/8fb5c5a984a8e16062e70282ce3d0fd6383ed864